### PR TITLE
Enabled backup analyzer, fixed content rendering

### DIFF
--- a/RemnantSaveGuardian/Views/Pages/BackupsPage.xaml
+++ b/RemnantSaveGuardian/Views/Pages/BackupsPage.xaml
@@ -61,7 +61,7 @@
                             </ui:MenuItem>
                         </Menu>
                     </ui:MenuItem>
-                    <ui:MenuItem Name="menuAnalyze" Header="{lex:Loc World Analyzer}" Visibility="Collapsed">
+                    <ui:MenuItem Name="menuAnalyze" Header="{lex:Loc World Analyzer}" Visibility="Visible">
                         <MenuItem.Icon>
                             <ui:SymbolIcon HorizontalAlignment="Left" Symbol="Globe24" />
                         </MenuItem.Icon>

--- a/RemnantSaveGuardian/Views/Windows/MainWindow.xaml.cs
+++ b/RemnantSaveGuardian/Views/Windows/MainWindow.xaml.cs
@@ -190,12 +190,11 @@ namespace RemnantSaveGuardian.Views.Windows
             navItem.ContextMenu.Items.Add(menuItem);
             navItem.Click += (clickSender, clickEvent) =>
             {
-                RootNavigation.NavigateExternal(page);
+                RootNavigation.Navigate(pageTag);
+                clickEvent.Handled = true;
             };
             ViewModel.NavigationItems.Add(navItem);
-            //RootFrame.Navigate(page);
-            RootNavigation.NavigateExternal(page);
-            navItem.IsActive = true;
+            RootNavigation.Navigate(pageTag);
         }
 
         private void Logger_MessageLogged(object? sender, MessageLoggedEventArgs e)


### PR DESCRIPTION
Closes #46 

The main issue was fixed by setting "clickEvent.Handled = true;"
And for the visuals only it was "NavigateExternal" instead of "Navigate" - because of this the vertical strip of "selected" was not shown.