### PR TITLE
update english name to match ingame values

### DIFF
--- a/RemnantSaveGuardian/locales/GameStrings.Designer.cs
+++ b/RemnantSaveGuardian/locales/GameStrings.Designer.cs
@@ -169,7 +169,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Chains of Amplification.
+        ///   Looks up a localized string similar to Chains Of Amplification.
         /// </summary>
         public static string Amulet_ChainsOfAmplification {
             get {
@@ -2167,7 +2167,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Sha&apos;Hala : Spectral Guardian of N&apos;Erud.
+        ///   Looks up a localized string similar to Sha’Hala : Spectral Guardian of N’Erud.
         /// </summary>
         public static string NerudGuardian {
             get {
@@ -2761,7 +2761,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Burden of the Rebel.
+        ///   Looks up a localized string similar to Burden Of The Rebel.
         /// </summary>
         public static string Ring_BurdenOfTheRebel {
             get {
@@ -3175,7 +3175,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Heart of the Wolf.
+        ///   Looks up a localized string similar to Heart Of The Wolf.
         /// </summary>
         public static string Ring_HeartOfTheWolf {
             get {
@@ -3436,7 +3436,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Ring of Restocking.
+        ///   Looks up a localized string similar to Ring Of Restocking.
         /// </summary>
         public static string Ring_RingOfRestocking {
             get {
@@ -3472,7 +3472,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Ring of the Robust.
+        ///   Looks up a localized string similar to Ring Of The Robust.
         /// </summary>
         public static string Ring_RingOfTheRobust {
             get {
@@ -3616,7 +3616,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Stone of Malevolence.
+        ///   Looks up a localized string similar to Stone Of Malevolence.
         /// </summary>
         public static string Ring_StoneOfMalevolence {
             get {

--- a/RemnantSaveGuardian/locales/GameStrings.Designer.cs
+++ b/RemnantSaveGuardian/locales/GameStrings.Designer.cs
@@ -4669,6 +4669,15 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Coach Gun.
+        /// </summary>
+        public static string Weapon_CoachGun {
+            get {
+                return ResourceManager.GetString("Weapon_CoachGun", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Crescent Moon.
         /// </summary>
         public static string Weapon_CrescentMoon {

--- a/RemnantSaveGuardian/locales/GameStrings.Designer.cs
+++ b/RemnantSaveGuardian/locales/GameStrings.Designer.cs
@@ -2608,6 +2608,15 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Band of Accord.
+        /// </summary>
+        public static string Ring_BandOfAccord {
+            get {
+                return ResourceManager.GetString("Ring_BandOfAccord", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Bisected Ring.
         /// </summary>
         public static string Ring_BisectedRing {

--- a/RemnantSaveGuardian/locales/GameStrings.Designer.cs
+++ b/RemnantSaveGuardian/locales/GameStrings.Designer.cs
@@ -709,6 +709,15 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Labyrinth.
+        /// </summary>
+        public static string Armor_Arcanist {
+            get {
+                return ResourceManager.GetString("Armor_Arcanist", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Archon.
         /// </summary>
         public static string Armor_Archon {

--- a/RemnantSaveGuardian/locales/GameStrings.Designer.cs
+++ b/RemnantSaveGuardian/locales/GameStrings.Designer.cs
@@ -1006,7 +1006,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Blood Moon Altar.
+        ///   Looks up a localized string similar to Bloodmoon Altar.
         /// </summary>
         public static string BloodMoon {
             get {
@@ -1150,7 +1150,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Dark Conduit.
+        ///   Looks up a localized string similar to The Dark Conduit.
         /// </summary>
         public static string DarkConduit {
             get {
@@ -1168,7 +1168,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Gwendil The Unburnt.
+        ///   Looks up a localized string similar to Gwendil : The Unburnt.
         /// </summary>
         public static string DranGrenadier {
             get {
@@ -2167,7 +2167,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Sha&apos;Hala: Spectral Guardian of N&apos;Erud.
+        ///   Looks up a localized string similar to Sha&apos;Hala : Spectral Guardian of N&apos;Erud.
         /// </summary>
         public static string NerudGuardian {
             get {
@@ -2572,7 +2572,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Anastasia&apos;s Inspiration.
+        ///   Looks up a localized string similar to Anastasija&apos;s Inspiration.
         /// </summary>
         public static string Ring_AnastasijasInspiration {
             get {
@@ -3625,7 +3625,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Stream Coupler Ring.
+        ///   Looks up a localized string similar to Stream Coupler.
         /// </summary>
         public static string Ring_StreamCoupler {
             get {
@@ -3949,7 +3949,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Tal Ratha.
+        ///   Looks up a localized string similar to Tal&apos;Ratha.
         /// </summary>
         public static string TalRatha {
             get {
@@ -3976,7 +3976,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Astropath&apos;s Respite.
+        ///   Looks up a localized string similar to Astropath&apos;s Respite.
         /// </summary>
         public static string TheAstroPathsRespite {
             get {
@@ -4093,7 +4093,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The Phantom Wasteland.
+        ///   Looks up a localized string similar to Phantom Wasteland.
         /// </summary>
         public static string ThePhantomWasteland {
             get {
@@ -4174,7 +4174,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Tormented Asylum.
+        ///   Looks up a localized string similar to The Tormented Asylum.
         /// </summary>
         public static string TormentedAsylum {
             get {
@@ -4813,7 +4813,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Katana.
+        ///   Looks up a localized string similar to Steel Katana.
         /// </summary>
         public static string Weapon_Katana {
             get {
@@ -4993,7 +4993,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Rupture Cannon.
+        ///   Looks up a localized string similar to Rupture Canon.
         /// </summary>
         public static string Weapon_RuptureCannon {
             get {
@@ -5128,7 +5128,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Chicago Typewritter.
+        ///   Looks up a localized string similar to Chicago Typewriter.
         /// </summary>
         public static string Weapon_TommyGun {
             get {

--- a/RemnantSaveGuardian/locales/GameStrings.Designer.cs
+++ b/RemnantSaveGuardian/locales/GameStrings.Designer.cs
@@ -5038,7 +5038,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Shotgun.
+        ///   Looks up a localized string similar to Ford&apos;s Scattergun.
         /// </summary>
         public static string Weapon_Shotgun {
             get {

--- a/RemnantSaveGuardian/locales/GameStrings.Designer.cs
+++ b/RemnantSaveGuardian/locales/GameStrings.Designer.cs
@@ -817,7 +817,7 @@ namespace RemnantSaveGuardian.locales {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invader.
+        ///   Looks up a localized string similar to Dendroid.
         /// </summary>
         public static string Armor_Invader {
             get {

--- a/RemnantSaveGuardian/locales/GameStrings.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.resx
@@ -433,7 +433,7 @@
     <value>Bloat King</value>
   </data>
   <data name="BloodMoon" xml:space="preserve">
-    <value>Blood Moon Altar</value>
+    <value>Bloodmoon Altar</value>
   </data>
   <data name="BoneHarvesterLair" xml:space="preserve">
     <value>Monster in the Drain</value>
@@ -481,13 +481,13 @@
     <value>The Custodian's Eye</value>
   </data>
   <data name="DarkConduit" xml:space="preserve">
-    <value>Dark Conduit</value>
+    <value>The Dark Conduit</value>
   </data>
   <data name="DormantNErudianFacility" xml:space="preserve">
     <value>Dormant N'Erudian Facility</value>
   </data>
   <data name="DranGrenadier" xml:space="preserve">
-    <value>Gwendil The Unburnt</value>
+    <value>Gwendil : The Unburnt</value>
   </data>
   <data name="DranOracle" xml:space="preserve">
     <value>Oracle of the Dran</value>
@@ -820,7 +820,7 @@
     <value>Mutators</value>
   </data>
   <data name="NerudGuardian" xml:space="preserve">
-    <value>Sha'Hala: Spectral Guardian of N'Erud</value>
+    <value>Sha'Hala : Spectral Guardian of N'Erud</value>
   </data>
   <data name="Nightweb" xml:space="preserve">
     <value>Nightweaver's Web</value>
@@ -958,7 +958,7 @@
     <value>Amber Moonstone</value>
   </data>
   <data name="Ring_AnastasijasInspiration" xml:space="preserve">
-    <value>Anastasia's Inspiration</value>
+    <value>Anastasija's Inspiration</value>
   </data>
   <data name="Ring_ArchersCrest" xml:space="preserve">
     <value>Archer's Crest</value>
@@ -1309,7 +1309,7 @@
     <value>Stone of Malevolence</value>
   </data>
   <data name="Ring_StreamCoupler" xml:space="preserve">
-    <value>Stream Coupler Ring</value>
+    <value>Stream Coupler</value>
   </data>
   <data name="Ring_StrongArmBand" xml:space="preserve">
     <value>Strong Arm Band</value>
@@ -1414,7 +1414,7 @@
     <value>Summoner</value>
   </data>
   <data name="TalRatha" xml:space="preserve">
-    <value>Tal Ratha</value>
+    <value>Tal'Ratha</value>
   </data>
   <data name="TerminusStation" xml:space="preserve">
     <value>Terminus Station</value>
@@ -1423,7 +1423,7 @@
     <value>TheTwistedChantry</value>
   </data>
   <data name="TheAstroPathsRespite" xml:space="preserve">
-    <value>The Astropath's Respite</value>
+    <value>Astropath's Respite</value>
   </data>
   <data name="TheCustodian" xml:space="preserve">
     <value>The Custodian</value>
@@ -1462,7 +1462,7 @@
     <value>The Nameless Nest</value>
   </data>
   <data name="ThePhantomWasteland" xml:space="preserve">
-    <value>The Phantom Wasteland</value>
+    <value>Phantom Wasteland</value>
   </data>
   <data name="ThePutridDomain" xml:space="preserve">
     <value>The Putrid Domain</value>
@@ -1489,7 +1489,7 @@
     <value>Tiller's Rest</value>
   </data>
   <data name="TormentedAsylum" xml:space="preserve">
-    <value>Tormented Asylum</value>
+    <value>The Tormented Asylum</value>
   </data>
   <data name="Tower" xml:space="preserve">
     <value>The Elevator</value>
@@ -1705,7 +1705,7 @@
     <value>Huntress Spear</value>
   </data>
   <data name="Weapon_Katana" xml:space="preserve">
-    <value>Katana</value>
+    <value>Steel Katana</value>
   </data>
   <data name="Weapon_KrellAxe" xml:space="preserve">
     <value>Krell Axe</value>
@@ -1765,7 +1765,7 @@
     <value>Rune Pistol</value>
   </data>
   <data name="Weapon_RuptureCannon" xml:space="preserve">
-    <value>Rupture Cannon</value>
+    <value>Rupture Canon</value>
   </data>
   <data name="Weapon_Sagittarius" xml:space="preserve">
     <value>Sagittarius</value>
@@ -1810,7 +1810,7 @@
     <value>Gas Giant</value>
   </data>
   <data name="Weapon_TommyGun" xml:space="preserve">
-    <value>Chicago Typewritter</value>
+    <value>Chicago Typewriter</value>
   </data>
   <data name="Weapon_TwistedArbalest" xml:space="preserve">
     <value>Twisted Arbalest</value>

--- a/RemnantSaveGuardian/locales/GameStrings.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.resx
@@ -1851,4 +1851,7 @@
   <data name="Ring_BandOfAccord" xml:space="preserve">
     <value>Band of Accord</value>
   </data>
+  <data name="Armor_Arcanist" xml:space="preserve">
+    <value>Labyrinth</value>
+  </data>
 </root>

--- a/RemnantSaveGuardian/locales/GameStrings.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.resx
@@ -157,7 +157,7 @@
     <value>Butcher's Fetish</value>
   </data>
   <data name="Amulet_ChainsOfAmplification" xml:space="preserve">
-    <value>Chains of Amplification</value>
+    <value>Chains Of Amplification</value>
   </data>
   <data name="Amulet_CleansingStone" xml:space="preserve">
     <value>Cleansing Stone</value>
@@ -820,7 +820,7 @@
     <value>Mutators</value>
   </data>
   <data name="NerudGuardian" xml:space="preserve">
-    <value>Sha'Hala : Spectral Guardian of N'Erud</value>
+    <value>Sha’Hala : Spectral Guardian of N’Erud</value>
   </data>
   <data name="Nightweb" xml:space="preserve">
     <value>Nightweaver's Web</value>
@@ -1021,7 +1021,7 @@
     <value>Burden of the Mariner</value>
   </data>
   <data name="Ring_BurdenOfTheRebel" xml:space="preserve">
-    <value>Burden of the Rebel</value>
+    <value>Burden Of The Rebel</value>
   </data>
   <data name="Ring_BurdenOfTheStargazer" xml:space="preserve">
     <value>Burden of the Stargazer</value>
@@ -1159,7 +1159,7 @@
     <value>Haymaker's Ring</value>
   </data>
   <data name="Ring_HeartOfTheWolf" xml:space="preserve">
-    <value>Heart of the Wolf</value>
+    <value>Heart Of The Wolf</value>
   </data>
   <data name="Ring_HexWard" xml:space="preserve">
     <value>Hex Ward</value>
@@ -1246,7 +1246,7 @@
     <value>Ring of Omens</value>
   </data>
   <data name="Ring_RingOfRestocking" xml:space="preserve">
-    <value>Ring of Restocking</value>
+    <value>Ring Of Restocking</value>
   </data>
   <data name="Ring_RingOfRetribution" xml:space="preserve">
     <value>Ring of Retribution</value>
@@ -1258,7 +1258,7 @@
     <value>Ring of the Forest Spirit</value>
   </data>
   <data name="Ring_RingOfTheRobust" xml:space="preserve">
-    <value>Ring of the Robust</value>
+    <value>Ring Of The Robust</value>
   </data>
   <data name="Ring_RockOfAnguish" xml:space="preserve">
     <value>Rock of Anguish</value>
@@ -1306,7 +1306,7 @@
     <value>Stone of Expanse</value>
   </data>
   <data name="Ring_StoneOfMalevolence" xml:space="preserve">
-    <value>Stone of Malevolence</value>
+    <value>Stone Of Malevolence</value>
   </data>
   <data name="Ring_StreamCoupler" xml:space="preserve">
     <value>Stream Coupler</value>

--- a/RemnantSaveGuardian/locales/GameStrings.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.resx
@@ -367,7 +367,7 @@
     <value>Nightstalker</value>
   </data>
   <data name="Armor_Invader" xml:space="preserve">
-    <value>Invader</value>
+    <value>Dendroid</value>
   </data>
   <data name="Armor_Legs" xml:space="preserve">
     <value>Legs</value>

--- a/RemnantSaveGuardian/locales/GameStrings.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.resx
@@ -1845,4 +1845,7 @@
   <data name="World_RootEarth" xml:space="preserve">
     <value>Root Earth</value>
   </data>
+  <data name="Weapon_CoachGun" xml:space="preserve">
+    <value>Coach Gun</value>
+  </data>
 </root>

--- a/RemnantSaveGuardian/locales/GameStrings.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.resx
@@ -1780,7 +1780,7 @@
     <value>Double Barrel</value>
   </data>
   <data name="Weapon_Shotgun" xml:space="preserve">
-    <value>Shotgun</value>
+    <value>Ford's Scattergun</value>
   </data>
   <data name="Weapon_SMG" xml:space="preserve">
     <value>MP60-R</value>

--- a/RemnantSaveGuardian/locales/GameStrings.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.resx
@@ -1848,4 +1848,7 @@
   <data name="Weapon_CoachGun" xml:space="preserve">
     <value>Coach Gun</value>
   </data>
+  <data name="Ring_BandOfAccord" xml:space="preserve">
+    <value>Band of Accord</value>
+  </data>
 </root>


### PR DESCRIPTION
Yep' I know that "Rupture Canon" is not right. But ingame it is with typo. Also, wiki link with typo too
https://remnant2.wiki.fextralife.com/Rupture+Canon

p.s. i create tool to auto translate gamestings.resx to all languages available in game, and i need this correct names. Will publish it later today.