### PR TITLE
Save window width & height to properties

### DIFF
--- a/RemnantSaveGuardian/App.config
+++ b/RemnantSaveGuardian/App.config
@@ -67,6 +67,12 @@
             <setting name="ShowCoopItems" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="WindowWidth" serializeAs="String">
+                <value>1100</value>
+            </setting>
+            <setting name="WindowHeight" serializeAs="String">
+                <value>650</value>
+            </setting>
         </RemnantSaveGuardian.Properties.Settings>
     </userSettings>
 </configuration>

--- a/RemnantSaveGuardian/Properties/Settings.Designer.cs
+++ b/RemnantSaveGuardian/Properties/Settings.Designer.cs
@@ -262,5 +262,29 @@ namespace RemnantSaveGuardian.Properties {
                 this["ShowCoopItems"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("1100")]
+        public int WindowWidth {
+            get {
+                return ((int)(this["WindowWidth"]));
+            }
+            set {
+                this["WindowWidth"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("650")]
+        public int WindowHeight {
+            get {
+                return ((int)(this["WindowHeight"]));
+            }
+            set {
+                this["WindowHeight"] = value;
+            }
+        }
     }
 }

--- a/RemnantSaveGuardian/Properties/Settings.settings
+++ b/RemnantSaveGuardian/Properties/Settings.settings
@@ -62,5 +62,11 @@
     <Setting Name="ShowCoopItems" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="WindowWidth" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">1100</Value>
+    </Setting>
+    <Setting Name="WindowHeight" Type="System.Int32" Scope="User">
+      <Value Profile="(Default)">650</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/RemnantSaveGuardian/Views/Windows/MainWindow.xaml
+++ b/RemnantSaveGuardian/Views/Windows/MainWindow.xaml
@@ -7,9 +7,10 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:pages="clr-namespace:RemnantSaveGuardian.Views.Pages"
     xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+    xmlns:settings="clr-namespace:RemnantSaveGuardian.Properties"
     Title="{Binding ViewModel.ApplicationTitle, Mode=OneWay}"
-    Width="1100"
-    Height="650"
+    Width="{Binding Path=WindowWidth, Source={x:Static settings:Settings.Default}, Mode=TwoWay}"
+    Height="{Binding Path=WindowHeight, Source={x:Static settings:Settings.Default}, Mode=TwoWay}"
     d:DataContext="{d:DesignInstance local:MainWindow,
                                      IsDesignTimeCreatable=True}"
     d:Background="{DynamicResource ApplicationBackgroundBrush}"


### PR DESCRIPTION
Add properties to save the window size and avoid resizing each time open the program.