### PR TITLE
Item: Shiny Hog Lure always lays on the entry of the path to Oink.

### DIFF
--- a/RemnantSaveGuardian/game.json
+++ b/RemnantSaveGuardian/game.json
@@ -507,6 +507,9 @@
       "Oink": [
         {
           "name": "/Items/Gems/Ranged/MetaGems/TwistingWounds/MetaGem_TwistingWounds"
+        },
+        {
+          "name": "/Items/Trinkets/Rings/ShinyHogLure/Ring_ShinyHogLure"
         }
       ],
       "AsylumChainsaw": [
@@ -633,11 +636,6 @@
       "Ring_RingOfTheRobust": [
         {
           "name": "/Items/Trinkets/Rings/RingOfTheRobust/Ring_RingOfTheRobust"
-        }
-      ],
-      "Ring_ShinyHogLure": [
-        {
-          "name": "/Items/Trinkets/Rings/ShinyHogLure/Ring_ShinyHogLure"
         }
       ],
       "Ring_StoneOfMalevolence": [


### PR DESCRIPTION
Fix issue that didn't show Shiny Hog Lure before