### PR TITLE
Add simplified Chinese translation (zh_Hans)

### DIFF
--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1417,7 +1417,7 @@
     <value>{Cass65_Notes}</value>
   </data>
   <data name="Ring_BrightSteelRing" xml:space="preserve">
-    <value>亮钢戒指</value>
+    <value>暗淡钢戒</value>
   </data>
   <data name="Ring_BrightSteelRing_Notes" xml:space="preserve">
     <value>完成至少15个世界故事后在老雷那里购买</value>
@@ -2555,5 +2555,41 @@
   </data>
   <data name="Relic_Consumable_ConstrainedHeart" xml:space="preserve">
     <value>约束之心</value>
+  </data>
+  <data name="Ring_WoodRing" xml:space="preserve">
+    <value>木质戒指</value>
+  </data>
+  <data name="World_DLC1" xml:space="preserve">
+    <value>真皇的苏醒DLC</value>
+  </data>
+  <data name="Weapon_AbyssalHook" xml:space="preserve">
+    <value>深渊之钩</value>
+  </data>
+  <data name="Material_Engram_Ritualist" xml:space="preserve">
+    <value>祭祀者</value>
+  </data>
+  <data name="Ring_ElevatedRing" xml:space="preserve">
+    <value>高升戒指</value>
+  </data>
+  <data name="Ring_CrimsonDreamstone" xml:space="preserve">
+    <value>绯红梦石</value>
+  </data>
+  <data name="Ring_RingOfTheCastaway" xml:space="preserve">
+    <value>Ring Of The Castaway</value>
+  </data>
+  <data name="Ring_LightHouseKeepersRing" xml:space="preserve">
+    <value>灯塔守卫的戒指</value>
+  </data>
+  <data name="Ring_AtonementFold" xml:space="preserve">
+    <value>赎罪皱襞</value>
+  </data>
+  <data name="Amulet_GiftOfMelancholy" xml:space="preserve">
+      <value>忧郁的礼物</value>
+  </data>
+  <data name="Amulet_GiftOfEuphoria" xml:space="preserve">
+      <value>极乐的礼物</value>
+  </data>
+  <data name="Weapon_Sparkfire" xml:space="preserve">
+      <value>星火霰弹枪</value>
   </data>
 </root>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -507,6 +507,12 @@
   <data name="Armor_Void" xml:space="preserve">
     <value>虚空</value>
   </data>
+  <data name="Armor_Head_LodestoneCrown_Notes" xml:space="preserve">
+    <value>在科尔凯特上锁房间的船上</value>
+  </data>
+  <data name="Ring_WoodRing_Notes" xml:space="preserve">
+    <value>洛斯曼随机掉落</value>
+  </data>
   <data name="Ascension Spire" xml:space="preserve">
     <value>升天尖塔</value>
   </data>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2598,6 +2598,42 @@
   <data name="MetaGem_TopHeavy" xml:space="preserve">
     <value>重装上阵</value>
   </data>
+  <data name="MetaGem_BottomFeeder_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_BottomHeavy_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_Edgelord_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_Ingenuity_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_KillSwitch_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_Latency_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_Opportunist_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_SequencedShot_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_Shocker_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_Stormbringer_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_TopHeavy_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_SpiritHealer_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
   <data name="Weapon_CorruptedAphelion" xml:space="preserve">
     <value>腐化远日点</value>
   </data>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2562,6 +2562,57 @@
   <data name="Relic_Consumable_ConstrainedHeart" xml:space="preserve">
     <value>约束之心</value>
   </data>
+  <data name="MetaGem_BottomFeeder" xml:space="preserve">
+    <value>底栖摄食者</value>
+  </data>
+  <data name="MetaGem_BottomHeavy" xml:space="preserve">
+    <value>轻装上阵</value>
+  </data>
+  <data name="MetaGem_Edgelord" xml:space="preserve">
+    <value>边缘行走</value>
+  </data>
+  <data name="MetaGem_Ingenuity" xml:space="preserve">
+    <value>独创精神</value>
+  </data>
+  <data name="MetaGem_KillSwitch" xml:space="preserve">
+    <value>杀戮开关</value>
+  </data>
+  <data name="MetaGem_Latency" xml:space="preserve">
+    <value>延迟</value>
+  </data>
+  <data name="MetaGem_Opportunist" xml:space="preserve">
+    <value>投机者</value>
+  </data>
+  <data name="MetaGem_SequencedShot" xml:space="preserve">
+    <value>鬼魅甲壳</value>
+  </data>
+  <data name="MetaGem_Shocker" xml:space="preserve">
+    <value>震颤者</value>
+  </data>
+  <data name="MetaGem_SpiritHealer" xml:space="preserve">
+    <value>灵魂医者</value>
+  </data>
+  <data name="MetaGem_Stormbringer" xml:space="preserve">
+    <value>风暴使者</value>
+  </data>
+  <data name="MetaGem_TopHeavy" xml:space="preserve">
+    <value>重装上阵</value>
+  </data>
+  <data name="Weapon_CorruptedAphelion" xml:space="preserve">
+    <value>腐化远日点</value>
+  </data>
+  <data name="Weapon_CorruptedDeceit" xml:space="preserve">
+    <value>腐化诡诈</value>
+  </data>
+  <data name="Weapon_CorruptedMerciless" xml:space="preserve">
+    <value>腐化无情</value>
+  </data>
+  <data name="Weapon_CorruptedMeridian" xml:space="preserve">
+    <value>腐化巅峰</value>
+  </data>
+  <data name="Weapon_CorruptedRunePistol" xml:space="preserve">
+    <value>腐化符文手枪</value>
+  </data>
   <data name="Ring_WoodRing" xml:space="preserve">
     <value>木质戒指</value>
   </data>


### PR DESCRIPTION
Add simplified Chinese translation for I owned based on items PR #182 and #185. Thank you for the excellent jobs!
I am a newbie in these programming languages. It is my first time modifying a `resx` file, and I wonder if `GameStrings.zh-Hans.resx` is the only file I need to edit to get the simplified Chinese works. Let me know if I need to correct anything / need to modify more places.
I know there are more items in the DLC, as summarised on Reddit. I have already obtained most of them, excluding some random drop items. So I can put their names on once they are added with their IDs in GameStrings.resx.