### PR TITLE
Add simplified Chinese translation (zh_Hans)

### DIFF
--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2665,7 +2665,7 @@
     <value>绯红梦石</value>
   </data>
   <data name="Ring_RingOfTheCastaway" xml:space="preserve">
-    <value>Ring Of The Castaway</value>
+    <value>放逐者戒指</value>
   </data>
   <data name="Ring_LightHouseKeepersRing" xml:space="preserve">
     <value>灯塔守卫的戒指</value>
@@ -2692,7 +2692,7 @@
     <value>祭品之石</value>
   </data>
   <data name="Ring_RingOfTheVain" xml:space="preserve">
-    <value>Ring Of The Vain</value>
+    <value>虚无指环</value>
   </data>
   <data name="Ring_PainlessObsidian" xml:space="preserve">
     <value>无痛黑曜石</value>
@@ -2704,7 +2704,7 @@
     <value>苦涩的纪念品</value>
   </data>
   <data name="Ring_DriedClayRing" xml:space="preserve">
-    <value>Dried Clay Ring</value>
+    <value>干陶戒指</value>
   </data>
   <data name="Ring_DigestedHogLure" xml:space="preserve">
     <value>已消化的猪饵料</value>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2655,7 +2655,7 @@
   <data name="Weapon_AbyssalHook" xml:space="preserve">
     <value>深渊之钩</value>
   </data>
-  <data name="Material_Engram_Ritualist" xml:space="preserve">
+  <data name="Item_HiddenContainer_Material_Engram_Ritualist" xml:space="preserve">
     <value>祭祀者</value>
   </data>
   <data name="Ring_ElevatedRing" xml:space="preserve">

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2847,4 +2847,16 @@
   <data name="Forgotten Null" xml:space="preserve">
     <value>忘却之无</value>
   </data>
+  <data name="Impaler" xml:space="preserve">
+    <value>布鲁恩，国王之刃</value>
+  </data>
+  <data name="OneTrueKingStory" xml:space="preserve">
+    <value>独一真皇</value>
+  </data>
+  <data name="SewerChamber" xml:space="preserve">
+    <value>被玷污的祭坛</value>
+  </data>
+  <data name="Witch" xml:space="preserve">
+    <value>失落女巫</value>
+  </data>
 </root>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2682,6 +2682,120 @@
   <data name="Weapon_Sparkfire" xml:space="preserve">
       <value>星火霰弹枪</value>
   </data>
+  <data name="Material_OccultVessel" xml:space="preserve">
+    <value>痛苦</value>
+  </data>
+  <data name="Ring_BurdenOfTheSciolist" xml:space="preserve">
+    <value>伪智者之负担</value>
+  </data>
+  <data name="Ring_OfferingStone" xml:space="preserve">
+    <value>Offering Stone</value>
+  </data>
+  <data name="Ring_RingOfTheVain" xml:space="preserve">
+    <value>Ring Of The Vain</value>
+  </data>
+  <data name="Ring_PainlessObsidian" xml:space="preserve">
+    <value>无痛黑曜石</value>
+  </data>
+  <data name="Ring_RedRingOfDeath" xml:space="preserve">
+    <value>死亡红戒</value>
+  </data>
+  <data name="Ring_BitterMemento" xml:space="preserve">
+    <value>苦涩的纪念品</value>
+  </data>
+  <data name="Ring_DriedClayRing" xml:space="preserve">
+    <value>Dried Clay Ring</value>
+  </data>
+  <data name="Ring_DigestedHogLure" xml:space="preserve">
+    <value>已消化的猪饵料</value>
+  </data>
+  <data name="Ring_ShadowOfMisery" xml:space="preserve">
+    <value>痛苦之影</value>
+  </data>
+  <data name="Ring_BurdenOfTheDeparted" xml:space="preserve">
+    <value>逝去者之负担</value>
+  </data>
+  <data name="Ring_BandOfTheFanatic" xml:space="preserve">
+    <value>狂热者指环</value>
+  </data>
+  <data name="Ring_BridgeWardensCrest" xml:space="preserve">
+    <value>守桥者纹章</value>
+  </data>
+  <data name="Ring_WhiteGlassBead" xml:space="preserve">
+    <value>白色玻璃珠</value>
+  </data>
+  <data name="Amulet_DeathSoakedIdol" xml:space="preserve">
+    <value>浸透死亡的神像</value>
+  </data>
+  <data name="Amulet_GiftOfTheUnbound" xml:space="preserve">
+    <value>不羁者的礼物</value>
+  </data>
+  <data name="Amulet_IndexOfTheScribe" xml:space="preserve">
+    <value>抄写员的索引</value>
+  </data>
+  <data name="Amulet_BirthrightOfTheLost" xml:space="preserve">
+    <value>失落者天权</value>
+  </data>
+  <data name="Amulet_WhisperingMarble" xml:space="preserve">
+    <value>低语大理石</value>
+  </data>
+  <data name="Amulet_BrewmastersCork" xml:space="preserve">
+    <value>酿酒大师的瓶塞</value>
+  </data>
+  <data name="Amulet_ParticipationMedal" xml:space="preserve">
+    <value>参与奖章</value>
+  </data>
+  <data name="Amulet_LegacyProtocol" xml:space="preserve">
+    <value>Legacy Protocol</value>
+  </data>
+  <data name="MetaGem_Guts" xml:space="preserve">
+    <value>越战越勇</value>
+  </data>
+  <data name="MetaGem_Dreadful" xml:space="preserve">
+    <value>可怖</value>
+  </data>
+  <data name="MetaGem_Maelstrom" xml:space="preserve">
+    <value>大漩涡</value>
+  </data>
+  <data name="MetaGem_Prophecy" xml:space="preserve">
+    <value>预言</value>
+  </data>
+  <data name="MetaGem_FetidWounds" xml:space="preserve">
+    <value>恶臭伤痕</value>
+  </data>
+  <data name="MetaGem_TaintedBlade" xml:space="preserve">
+    <value>污秽之刃</value>
+  </data>
+  <data name="MetaGem_Sleeper" xml:space="preserve">
+    <value>沉睡者</value>
+  </data>
+  <data name="Weapon_RitualistScythe" xml:space="preserve">
+    <value>祭祀者镰刀</value>
+  </data>
+  <data name="Weapon_Wrathbringer" xml:space="preserve">
+    <value>狂怒使者</value>
+  </data>
+  <data name="Weapon_Scythe" xml:space="preserve">
+    <value>钢镰刀</value>
+  </data>
+  <data name="Weapon_Monarch" xml:space="preserve">
+    <value>君王</value>
+  </data>
+  <data name="Mod_CreepingMist" xml:space="preserve">
+    <value>蔓延迷雾</value>
+  </data>
+  <data name="Mod_ChainOfCommand" xml:space="preserve">
+    <value>命令链</value>
+  </data>
+  <data name="Relic_Consumable_PaperHeart" xml:space="preserve">
+    <value>纸之心</value>
+  </data>
+  <data name="Relic_Consumable_BrokenHeart" xml:space="preserve">
+    <value>破碎之心</value>
+  </data>
+  <data name="Trait_Affliction" xml:space="preserve">
+    <value>折磨</value>
+  </data>
   <data name="Derelict Lighthouse" xml:space="preserve">
     <value>秘密灯塔</value>
   </data>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2658,6 +2658,9 @@
   <data name="Relic_Consumable_PaperHeart" xml:space="preserve">
     <value>纸之心</value>
   </data>
+  <data name="Trait_DarkPact" xml:space="preserve">
+    <value>黑暗契约</value>
+  </data>
   <data name="Weapon_Sparkfire" xml:space="preserve">
       <value>星火霰弹枪</value>
   </data>
@@ -2700,8 +2703,17 @@
   <data name="MetaGem_Sleeper" xml:space="preserve">
     <value>沉睡者</value>
   </data>
+  <data name="MetaGem_Executor" xml:space="preserve">
+    <value>执行者</value>
+  </data>
   <data name="Mod_CreepingMist" xml:space="preserve">
     <value>蔓延迷雾</value>
+  </data>
+  <data name="Mod_KnightGuard" xml:space="preserve">
+    <value>骑士守卫</value>
+  </data>
+  <data name="Mod_RingOfSpears" xml:space="preserve">
+    <value>长矛戒指</value>
   </data>
   <data name="Mod_ChainOfCommand" xml:space="preserve">
     <value>命令链</value>
@@ -2772,6 +2784,9 @@
   <data name="Ring_ElevatedRing" xml:space="preserve">
     <value>高升戒指</value>
   </data>
+  <data name="Ring_JewelOfTheBeholden" xml:space="preserve">
+    <value>感恩珠宝</value>
+  </data>
   <data name="Ring_LightHouseKeepersRing" xml:space="preserve">
     <value>灯塔守卫的戒指</value>
   </data>
@@ -2784,6 +2799,9 @@
   <data name="Ring_RedRingOfDeath" xml:space="preserve">
     <value>死亡红戒</value>
   </data>
+  <data name="Ring_RingOfInfiniteDamage" xml:space="preserve">
+    <value>无限伤害戒指</value>
+  </data>
   <data name="Ring_RingOfTheCastaway" xml:space="preserve">
     <value>放逐者戒指</value>
   </data>
@@ -2792,6 +2810,9 @@
   </data>
   <data name="Ring_ShadowOfMisery" xml:space="preserve">
     <value>痛苦之影</value>
+  </data>
+  <data name="Ring_ShaedStone" xml:space="preserve">
+    <value>刹邸之石</value>
   </data>
   <data name="Ring_WhiteGlassBead" xml:space="preserve">
     <value>白色玻璃珠</value>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2808,13 +2808,13 @@
   <data name="Armor_Ritualist" xml:space="preserve">
     <value>狂热者套装</value>
   </data>
-  <data name="Derelict Lighthouse" xml:space="preserve">
+  <data name="Lighthouse" xml:space="preserve">
     <value>秘密灯塔</value>
   </data>
   <data name="Drowned Wen" xml:space="preserve">
     <value>淹没之城</value>
   </data>
-  <data name="Forlorn Coast" xml:space="preserve">
+  <data name="Quest_Story_OTK" xml:space="preserve">
     <value>凄凉海岸</value>
   </data>
   <data name="Glistering Cloister" xml:space="preserve">
@@ -2838,7 +2838,7 @@
   <data name="Walk of Remembrance" xml:space="preserve">
     <value>纪念之行</value>
   </data>
-  <data name="Ethereal Manor" xml:space="preserve">
+  <data name="BurningCity_DLC" xml:space="preserve">
     <value>飘渺庄园</value>
   </data>
   <data name="Consecrated Throne" xml:space="preserve">

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1417,7 +1417,7 @@
     <value>{Cass65_Notes}</value>
   </data>
   <data name="Ring_BrightSteelRing" xml:space="preserve">
-    <value>亮钢戒指</value>
+    <value>暗淡钢戒</value>
   </data>
   <data name="Ring_BrightSteelRing_Notes" xml:space="preserve">
     <value>完成至少15个世界故事后在老雷那里购买</value>
@@ -2555,5 +2555,41 @@
   </data>
   <data name="Relic_Consumable_ConstrainedHeart" xml:space="preserve">
     <value>约束之心</value>
+  </data>
+  <data name="Ring_WoodRing" xml:space="preserve">
+    <value>木质戒指</value>
+  </data>
+  <data name="World_DLC1" xml:space="preserve">
+    <value>真皇的苏醒DLC</value>
+  </data>
+  <data name="Weapon_AbyssalHook" xml:space="preserve">
+    <value>深渊之钩</value>
+  </data>
+  <data name="Material_Engram_Ritualist" xml:space="preserve">
+    <value>祭祀者</value>
+  </data>
+  <data name="Ring_ElevatedRing" xml:space="preserve">
+    <value>高升戒指</value>
+  </data>
+  <data name="Ring_CrimsonDreamstone" xml:space="preserve">
+    <value>绯红梦石</value>
+  </data>
+  <data name="Ring_RingOfTheCastaway" xml:space="preserve">
+    <value>Ring Of The Castaway</value>
+  </data>
+  <data name="Ring_LightHouseKeepersRing" xml:space="preserve">
+    <value>灯塔守卫的戒指</value>
+  </data>
+  <data name="Ring_AtonementFold" xml:space="preserve">
+    <value>赎罪皱襞</value>
+  </data>
+  <data name="Amulet_GiftOfMelancholy" xml:space="preserve">
+      <value>忧郁的礼物</value>
+  </data>
+  <data name="Amulet_GiftOfEuphoria" xml:space="preserve">
+      <value>极乐的礼物</value>
+  </data>
+  <data name="Weapon_Sparkfire" xml:space="preserve">
+      <value>星火霰弹枪</value>
   </data>
 </root>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2689,7 +2689,7 @@
     <value>伪智者之负担</value>
   </data>
   <data name="Ring_OfferingStone" xml:space="preserve">
-    <value>Offering Stone</value>
+    <value>祭品之石</value>
   </data>
   <data name="Ring_RingOfTheVain" xml:space="preserve">
     <value>Ring Of The Vain</value>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2643,125 +2643,53 @@
   <data name="Weapon_CorruptedRunePistol" xml:space="preserve">
     <value>腐化符文手枪</value>
   </data>
-  <data name="Ring_WoodRing" xml:space="preserve">
-    <value>木质戒指</value>
-  </data>
-  <data name="World_DLC1" xml:space="preserve">
-    <value>真皇的苏醒DLC</value>
-  </data>
-  <data name="Weapon_AbyssalHook" xml:space="preserve">
-    <value>深渊之钩</value>
-  </data>
   <data name="Item_HiddenContainer_Material_Engram_Ritualist" xml:space="preserve">
     <value>祭祀者(心痕)</value>
   </data>
-  <data name="Ring_ElevatedRing" xml:space="preserve">
-    <value>高升戒指</value>
+  <data name="Armor_Ritualist" xml:space="preserve">
+    <value>狂热者套装</value>
   </data>
-  <data name="Ring_CrimsonDreamstone" xml:space="preserve">
-    <value>绯红梦石</value>
+  <data name="Armor_RedPrinceArmor" xml:space="preserve">
+    <value>绯红守卫套装</value>
   </data>
-  <data name="Ring_RingOfTheCastaway" xml:space="preserve">
-    <value>放逐者戒指</value>
+  <data name="Relic_Consumable_BrokenHeart" xml:space="preserve">
+    <value>破碎之心</value>
   </data>
-  <data name="Ring_LightHouseKeepersRing" xml:space="preserve">
-    <value>灯塔守卫的戒指</value>
-  </data>
-  <data name="Ring_AtonementFold" xml:space="preserve">
-    <value>赎罪皱襞</value>
-  </data>
-  <data name="Amulet_GiftOfMelancholy" xml:space="preserve">
-      <value>忧郁的礼物</value>
-  </data>
-  <data name="Amulet_GiftOfEuphoria" xml:space="preserve">
-      <value>极乐的礼物</value>
+  <data name="Relic_Consumable_PaperHeart" xml:space="preserve">
+    <value>纸之心</value>
   </data>
   <data name="Weapon_Sparkfire" xml:space="preserve">
       <value>星火霰弹枪</value>
   </data>
+  <data name="Weapon_Monarch" xml:space="preserve">
+    <value>君王</value>
+  </data>
   <data name="Material_OccultVessel" xml:space="preserve">
     <value>痛苦</value>
   </data>
-  <data name="Ring_BurdenOfTheSciolist" xml:space="preserve">
-    <value>伪智者之负担</value>
+  <data name="Weapon_Wrathbringer" xml:space="preserve">
+    <value>狂怒使者</value>
   </data>
-  <data name="Ring_OfferingStone" xml:space="preserve">
-    <value>祭品之石</value>
+  <data name="Weapon_AbyssalHook" xml:space="preserve">
+    <value>深渊之钩</value>
   </data>
-  <data name="Ring_RingOfTheVain" xml:space="preserve">
-    <value>虚无指环</value>
+  <data name="Weapon_Scythe" xml:space="preserve">
+    <value>钢镰刀</value>
   </data>
-  <data name="Ring_PainlessObsidian" xml:space="preserve">
-    <value>无痛黑曜石</value>
-  </data>
-  <data name="Ring_RedRingOfDeath" xml:space="preserve">
-    <value>死亡红戒</value>
-  </data>
-  <data name="Ring_BitterMemento" xml:space="preserve">
-    <value>苦涩的纪念品</value>
-  </data>
-  <data name="Ring_DriedClayRing" xml:space="preserve">
-    <value>干陶戒指</value>
-  </data>
-  <data name="Ring_DigestedHogLure" xml:space="preserve">
-    <value>已消化的猪饵料</value>
-  </data>
-  <data name="Ring_ShadowOfMisery" xml:space="preserve">
-    <value>痛苦之影</value>
-  </data>
-  <data name="Ring_BurdenOfTheDeparted" xml:space="preserve">
-    <value>逝去者之负担</value>
-  </data>
-  <data name="Ring_BandOfTheFanatic" xml:space="preserve">
-    <value>狂热者指环</value>
-  </data>
-  <data name="Ring_BridgeWardensCrest" xml:space="preserve">
-    <value>守桥者纹章</value>
-  </data>
-  <data name="Ring_WhiteGlassBead" xml:space="preserve">
-    <value>白色玻璃珠</value>
-  </data>
-  <data name="Ring_PowerComplex" xml:space="preserve">
-    <value>能量园区</value>
-  </data>
-  <data name="Amulet_LegacyProtocol" xml:space="preserve">
-    <value>旧日协议</value>
-  </data>
-  <data name="Ring_ATaeriiBooster" xml:space="preserve">
-    <value>阿泰里助推</value>
-  </data>
-  <data name="Ring_BrawlersPride" xml:space="preserve">
-    <value>格斗家的骄傲</value>
-  </data>
-  <data name="Amulet_SinisterTotem" xml:space="preserve">
-    <value>罪恶图腾</value>
-  </data>
-  <data name="Ring_SoulShard" xml:space="preserve">
-    <value>灵魂碎片</value>
-  </data>
-  <data name="Amulet_DeathSoakedIdol" xml:space="preserve">
-    <value>浸透死亡的神像</value>
-  </data>
-  <data name="Amulet_GiftOfTheUnbound" xml:space="preserve">
-    <value>不羁者的礼物</value>
-  </data>
-  <data name="Amulet_IndexOfTheScribe" xml:space="preserve">
-    <value>抄写员的索引</value>
-  </data>
-  <data name="Amulet_BirthrightOfTheLost" xml:space="preserve">
-    <value>失落者天权</value>
-  </data>
-  <data name="Amulet_WhisperingMarble" xml:space="preserve">
-    <value>低语大理石</value>
-  </data>
-  <data name="Amulet_BrewmastersCork" xml:space="preserve">
-    <value>酿酒大师的瓶塞</value>
-  </data>
-  <data name="Amulet_ParticipationMedal" xml:space="preserve">
-    <value>参与奖章</value>
+  <data name="Weapon_RitualistScythe" xml:space="preserve">
+    <value>祭祀者镰刀</value>
   </data>
   <data name="MetaGem_Guts" xml:space="preserve">
     <value>越战越勇</value>
+  </data>
+  <data name="MetaGem_TaintedBlade" xml:space="preserve">
+    <value>污秽之刃</value>
+  </data>
+  <data name="MetaGem_FetidWounds" xml:space="preserve">
+    <value>恶臭伤痕</value>
+  </data>
+  <data name="MetaGem_Prophecy" xml:space="preserve">
+    <value>预言</value>
   </data>
   <data name="MetaGem_Dreadful" xml:space="preserve">
     <value>可怖</value>
@@ -2769,29 +2697,8 @@
   <data name="MetaGem_Maelstrom" xml:space="preserve">
     <value>大漩涡</value>
   </data>
-  <data name="MetaGem_Prophecy" xml:space="preserve">
-    <value>预言</value>
-  </data>
-  <data name="MetaGem_FetidWounds" xml:space="preserve">
-    <value>恶臭伤痕</value>
-  </data>
-  <data name="MetaGem_TaintedBlade" xml:space="preserve">
-    <value>污秽之刃</value>
-  </data>
   <data name="MetaGem_Sleeper" xml:space="preserve">
     <value>沉睡者</value>
-  </data>
-  <data name="Weapon_RitualistScythe" xml:space="preserve">
-    <value>祭祀者镰刀</value>
-  </data>
-  <data name="Weapon_Wrathbringer" xml:space="preserve">
-    <value>狂怒使者</value>
-  </data>
-  <data name="Weapon_Scythe" xml:space="preserve">
-    <value>钢镰刀</value>
-  </data>
-  <data name="Weapon_Monarch" xml:space="preserve">
-    <value>君王</value>
   </data>
   <data name="Mod_CreepingMist" xml:space="preserve">
     <value>蔓延迷雾</value>
@@ -2799,23 +2706,116 @@
   <data name="Mod_ChainOfCommand" xml:space="preserve">
     <value>命令链</value>
   </data>
-  <data name="Relic_Consumable_PaperHeart" xml:space="preserve">
-    <value>纸之心</value>
+  <data name="Amulet_BirthrightOfTheLost" xml:space="preserve">
+    <value>失落者天权</value>
   </data>
-  <data name="Relic_Consumable_BrokenHeart" xml:space="preserve">
-    <value>破碎之心</value>
-  </data>
-  <data name="Trait_Affliction" xml:space="preserve">
-    <value>折磨</value>
+  <data name="Amulet_BrewmastersCork" xml:space="preserve">
+    <value>酿酒大师的瓶塞</value>
   </data>
   <data name="Amulet_CostOfBetrayal" xml:space="preserve">
     <value>背叛的代价</value>
   </data>
-  <data name="Armor_RedPrinceArmor" xml:space="preserve">
-    <value>绯红守卫套装</value>
+  <data name="Amulet_DeathSoakedIdol" xml:space="preserve">
+    <value>浸透死亡的神像</value>
   </data>
-  <data name="Armor_Ritualist" xml:space="preserve">
-    <value>狂热者套装</value>
+  <data name="Amulet_GiftOfEuphoria" xml:space="preserve">
+      <value>极乐的礼物</value>
+  </data>
+  <data name="Amulet_GiftOfMelancholy" xml:space="preserve">
+      <value>忧郁的礼物</value>
+  </data>
+  <data name="Amulet_GiftOfTheUnbound" xml:space="preserve">
+    <value>不羁者的礼物</value>
+  </data>
+  <data name="Amulet_IndexOfTheScribe" xml:space="preserve">
+    <value>抄写员的索引</value>
+  </data>
+  <data name="Amulet_ParticipationMedal" xml:space="preserve">
+    <value>参与奖章</value>
+  </data>
+  <data name="Amulet_WhisperingMarble" xml:space="preserve">
+    <value>低语大理石</value>
+  </data>
+  <data name="Amulet_LegacyProtocol" xml:space="preserve">
+    <value>旧日协议</value>
+  </data>
+  <data name="Amulet_SinisterTotem" xml:space="preserve">
+    <value>罪恶图腾</value>
+  </data>
+  <data name="Ring_AtonementFold" xml:space="preserve">
+    <value>赎罪皱襞</value>
+  </data>
+  <data name="Ring_BandOfTheFanatic" xml:space="preserve">
+    <value>狂热者指环</value>
+  </data>
+  <data name="Ring_BitterMemento" xml:space="preserve">
+    <value>苦涩的纪念品</value>
+  </data>
+  <data name="Ring_BridgeWardensCrest" xml:space="preserve">
+    <value>守桥者纹章</value>
+  </data>
+  <data name="Ring_BurdenOfTheDeparted" xml:space="preserve">
+    <value>逝去者之负担</value>
+  </data>
+  <data name="Ring_BurdenOfTheSciolist" xml:space="preserve">
+    <value>伪智者之负担</value>
+  </data>
+  <data name="Ring_CrimsonDreamstone" xml:space="preserve">
+    <value>绯红梦石</value>
+  </data>
+  <data name="Ring_DigestedHogLure" xml:space="preserve">
+    <value>已消化的猪饵料</value>
+  </data>
+  <data name="Ring_DriedClayRing" xml:space="preserve">
+    <value>干陶戒指</value>
+  </data>
+  <data name="Ring_ElevatedRing" xml:space="preserve">
+    <value>高升戒指</value>
+  </data>
+  <data name="Ring_LightHouseKeepersRing" xml:space="preserve">
+    <value>灯塔守卫的戒指</value>
+  </data>
+  <data name="Ring_OfferingStone" xml:space="preserve">
+    <value>祭品之石</value>
+  </data>
+  <data name="Ring_PainlessObsidian" xml:space="preserve">
+    <value>无痛黑曜石</value>
+  </data>
+  <data name="Ring_RedRingOfDeath" xml:space="preserve">
+    <value>死亡红戒</value>
+  </data>
+  <data name="Ring_RingOfTheCastaway" xml:space="preserve">
+    <value>放逐者戒指</value>
+  </data>
+  <data name="Ring_RingOfTheVain" xml:space="preserve">
+    <value>虚无指环</value>
+  </data>
+  <data name="Ring_ShadowOfMisery" xml:space="preserve">
+    <value>痛苦之影</value>
+  </data>
+  <data name="Ring_WhiteGlassBead" xml:space="preserve">
+    <value>白色玻璃珠</value>
+  </data>
+  <data name="Ring_WoodRing" xml:space="preserve">
+    <value>木质戒指</value>
+  </data>
+  <data name="Ring_ATaeriiBooster" xml:space="preserve">
+    <value>阿泰里助推</value>
+  </data>
+  <data name="Ring_PowerComplex" xml:space="preserve">
+    <value>能量园区</value>
+  </data>
+  <data name="Ring_BrawlersPride" xml:space="preserve">
+    <value>格斗家的骄傲</value>
+  </data>
+  <data name="Ring_SoulShard" xml:space="preserve">
+    <value>灵魂碎片</value>
+  </data>
+  <data name="Trait_Affliction" xml:space="preserve">
+    <value>折磨</value>
+  </data>
+  <data name="World_DLC1" xml:space="preserve">
+    <value>真皇的苏醒DLC</value>
   </data>
   <data name="Lighthouse" xml:space="preserve">
     <value>秘密灯塔</value>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2556,6 +2556,57 @@
   <data name="Relic_Consumable_ConstrainedHeart" xml:space="preserve">
     <value>约束之心</value>
   </data>
+  <data name="MetaGem_BottomFeeder" xml:space="preserve">
+    <value>底栖摄食者</value>
+  </data>
+  <data name="MetaGem_BottomHeavy" xml:space="preserve">
+    <value>轻装上阵</value>
+  </data>
+  <data name="MetaGem_Edgelord" xml:space="preserve">
+    <value>边缘行走</value>
+  </data>
+  <data name="MetaGem_Ingenuity" xml:space="preserve">
+    <value>独创精神</value>
+  </data>
+  <data name="MetaGem_KillSwitch" xml:space="preserve">
+    <value>杀戮开关</value>
+  </data>
+  <data name="MetaGem_Latency" xml:space="preserve">
+    <value>延迟</value>
+  </data>
+  <data name="MetaGem_Opportunist" xml:space="preserve">
+    <value>投机者</value>
+  </data>
+  <data name="MetaGem_SequencedShot" xml:space="preserve">
+    <value>鬼魅甲壳</value>
+  </data>
+  <data name="MetaGem_Shocker" xml:space="preserve">
+    <value>震颤者</value>
+  </data>
+  <data name="MetaGem_SpiritHealer" xml:space="preserve">
+    <value>灵魂医者</value>
+  </data>
+  <data name="MetaGem_Stormbringer" xml:space="preserve">
+    <value>风暴使者</value>
+  </data>
+  <data name="MetaGem_TopHeavy" xml:space="preserve">
+    <value>重装上阵</value>
+  </data>
+  <data name="Weapon_CorruptedAphelion" xml:space="preserve">
+    <value>腐化远日点</value>
+  </data>
+  <data name="Weapon_CorruptedDeceit" xml:space="preserve">
+    <value>腐化诡诈</value>
+  </data>
+  <data name="Weapon_CorruptedMerciless" xml:space="preserve">
+    <value>腐化无情</value>
+  </data>
+  <data name="Weapon_CorruptedMeridian" xml:space="preserve">
+    <value>腐化巅峰</value>
+  </data>
+  <data name="Weapon_CorruptedRunePistol" xml:space="preserve">
+    <value>腐化符文手枪</value>
+  </data>
   <data name="Ring_WoodRing" xml:space="preserve">
     <value>木质戒指</value>
   </data>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2859,4 +2859,16 @@
   <data name="Witch" xml:space="preserve">
     <value>失落女巫</value>
   </data>
+  <data name="GardenMaze" xml:space="preserve">
+    <value>The Maze</value>
+  </data>
+  <data name="Halls_DLC" xml:space="preserve">
+    <value>Mirror Floor</value>
+  </data>
+  <data name="Sewer_DLC" xml:space="preserve">
+    <value>Sewer Hole</value>
+  </data>
+  <data name="Quest_Item_DLC_DreamLevel" xml:space="preserve">
+    <value>Enter the Dream</value>
+  </data>
 </root>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2724,7 +2724,7 @@
   <data name="Ring_PowerComplex" xml:space="preserve">
     <value>能量园区</value>
   </data>
-  <data name="Ring_LegacyProtocol" xml:space="preserve">
+  <data name="Amulet_LegacyProtocol" xml:space="preserve">
     <value>旧日协议</value>
   </data>
   <data name="Ring_ATaeriiBooster" xml:space="preserve">
@@ -2750,9 +2750,6 @@
   </data>
   <data name="Amulet_ParticipationMedal" xml:space="preserve">
     <value>参与奖章</value>
-  </data>
-  <data name="Amulet_LegacyProtocol" xml:space="preserve">
-    <value>旧日协议</value>
   </data>
   <data name="MetaGem_Guts" xml:space="preserve">
     <value>越战越勇</value>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2730,6 +2730,15 @@
   <data name="Ring_ATaeriiBooster" xml:space="preserve">
     <value>阿泰里助推</value>
   </data>
+  <data name="Ring_BrawlersPride" xml:space="preserve">
+    <value>格斗家的骄傲</value>
+  </data>
+  <data name="Amulet_SinisterTotem" xml:space="preserve">
+    <value>罪恶图腾</value>
+  </data>
+  <data name="Ring_SoulShard" xml:space="preserve">
+    <value>灵魂碎片</value>
+  </data>
   <data name="Amulet_DeathSoakedIdol" xml:space="preserve">
     <value>浸透死亡的神像</value>
   </data>
@@ -2801,9 +2810,6 @@
   </data>
   <data name="Amulet_CostOfBetrayal" xml:space="preserve">
     <value>背叛的代价</value>
-  </data>
-  <data name="Amulet_SinisterTotem" xml:space="preserve">
-    <value>Sinister Totem</value>
   </data>
   <data name="Armor_RedPrinceArmor" xml:space="preserve">
     <value>绯红守卫套装</value>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -817,25 +817,25 @@
     <value>炼金术师(心痕)</value>
   </data>
   <data name="Item_HiddenContainer_Material_Engram_Archon" xml:space="preserve">
-    <value>执政官</value>
+    <value>执政官(心痕)</value>
   </data>
   <data name="Item_HiddenContainer_Material_Engram_Challenger" xml:space="preserve">
-    <value>挑战者</value>
+    <value>挑战者(心痕)</value>
   </data>
   <data name="Item_HiddenContainer_Material_Engram_Challenger_Notes" xml:space="preserve">
     <value>从老雷那里购买旧金属工具</value>
   </data>
   <data name="Item_HiddenContainer_Material_Engram_Engineer" xml:space="preserve">
-    <value>工程师</value>
+    <value>工程师(心痕)</value>
   </data>
   <data name="Item_HiddenContainer_Material_Engram_Gunslinger" xml:space="preserve">
-    <value>枪手</value>
+    <value>枪手(心痕)</value>
   </data>
   <data name="Item_HiddenContainer_Material_Engram_Gunslinger_Notes" xml:space="preserve">
     <value>{Amulet_GunslingersCharm_Notes}</value>
   </data>
   <data name="Item_HiddenContainer_Material_Engram_Handler" xml:space="preserve">
-    <value>驯兽师</value>
+    <value>驯兽师(心痕)</value>
   </data>
   <data name="Item_HiddenContainer_Material_Engram_Handler_Notes" xml:space="preserve">
     <value>从泥牙那里购买古老哨子</value>
@@ -2656,7 +2656,7 @@
     <value>深渊之钩</value>
   </data>
   <data name="Item_HiddenContainer_Material_Engram_Ritualist" xml:space="preserve">
-    <value>祭祀者</value>
+    <value>祭祀者(心痕)</value>
   </data>
   <data name="Ring_ElevatedRing" xml:space="preserve">
     <value>高升戒指</value>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2796,6 +2796,18 @@
   <data name="Trait_Affliction" xml:space="preserve">
     <value>折磨</value>
   </data>
+  <data name="Amulet_CostOfBetrayal" xml:space="preserve">
+    <value>背叛的代价</value>
+  </data>
+  <data name="Amulet_SinisterTotem" xml:space="preserve">
+    <value>Sinister Totem</value>
+  </data>
+  <data name="Armor_RedPrinceArmor" xml:space="preserve">
+    <value>绯红守卫套装</value>
+  </data>
+  <data name="Armor_Ritualist" xml:space="preserve">
+    <value>狂热者套装</value>
+  </data>
   <data name="Derelict Lighthouse" xml:space="preserve">
     <value>秘密灯塔</value>
   </data>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2646,9 +2646,6 @@
   <data name="Ring_WoodRing" xml:space="preserve">
     <value>木质戒指</value>
   </data>
-  <data name="Ring_WoodRing_Notes" xml:space="preserve">
-    <value>洛斯曼随机掉落</value>
-  </data>
   <data name="World_DLC1" xml:space="preserve">
     <value>真皇的苏醒DLC</value>
   </data>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2592,6 +2592,42 @@
   <data name="MetaGem_TopHeavy" xml:space="preserve">
     <value>重装上阵</value>
   </data>
+  <data name="MetaGem_BottomFeeder_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_BottomHeavy_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_Edgelord_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_Ingenuity_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_KillSwitch_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_Latency_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_Opportunist_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_SequencedShot_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_Shocker_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_Stormbringer_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_TopHeavy_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
+  <data name="MetaGem_SpiritHealer_Notes" xml:space="preserve">
+    <value>畸变怪物随机掉落</value>
+  </data>
   <data name="Weapon_CorruptedAphelion" xml:space="preserve">
     <value>腐化远日点</value>
   </data>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2721,6 +2721,15 @@
   <data name="Ring_WhiteGlassBead" xml:space="preserve">
     <value>白色玻璃珠</value>
   </data>
+  <data name="Ring_PowerComplex" xml:space="preserve">
+    <value>能量园区</value>
+  </data>
+  <data name="Ring_LegacyProtocol" xml:space="preserve">
+    <value>旧日协议</value>
+  </data>
+  <data name="Ring_ATaeriiBooster" xml:space="preserve">
+    <value>阿泰里助推</value>
+  </data>
   <data name="Amulet_DeathSoakedIdol" xml:space="preserve">
     <value>浸透死亡的神像</value>
   </data>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2746,7 +2746,7 @@
     <value>参与奖章</value>
   </data>
   <data name="Amulet_LegacyProtocol" xml:space="preserve">
-    <value>Legacy Protocol</value>
+    <value>旧日协议</value>
   </data>
   <data name="MetaGem_Guts" xml:space="preserve">
     <value>越战越勇</value>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2682,4 +2682,43 @@
   <data name="Weapon_Sparkfire" xml:space="preserve">
       <value>星火霰弹枪</value>
   </data>
+  <data name="Derelict Lighthouse" xml:space="preserve">
+    <value>秘密灯塔</value>
+  </data>
+  <data name="Drowned Wen" xml:space="preserve">
+    <value>淹没之城</value>
+  </data>
+  <data name="Forlorn Coast" xml:space="preserve">
+    <value>凄凉海岸</value>
+  </data>
+  <data name="Glistering Cloister" xml:space="preserve">
+    <value>闪光回廊</value>
+  </data>
+  <data name="Mournful Promenade" xml:space="preserve">
+    <value>哀悼长廊</value>
+  </data>
+  <data name="Pathway of the Fallen" xml:space="preserve">
+    <value>堕落之路</value>
+  </data>
+  <data name="Palace of the One True King" xml:space="preserve">
+    <value>独一真皇的宫殿</value>
+  </data>
+  <data name="Sunken Haunt" xml:space="preserve">
+    <value>失落之地</value>
+  </data>
+  <data name="The Forgotten Commune" xml:space="preserve">
+    <value>被遗忘的公社</value>
+  </data>
+  <data name="Walk of Remembrance" xml:space="preserve">
+    <value>纪念之行</value>
+  </data>
+  <data name="Ethereal Manor" xml:space="preserve">
+    <value>飘渺庄园</value>
+  </data>
+  <data name="Consecrated Throne" xml:space="preserve">
+    <value>祝圣王座</value>
+  </data>
+  <data name="Forgotten Null" xml:space="preserve">
+    <value>忘却之无</value>
+  </data>
 </root>

--- a/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
+++ b/RemnantSaveGuardian/locales/GameStrings.zh-Hans.resx
@@ -2559,6 +2559,9 @@
   <data name="Ring_WoodRing" xml:space="preserve">
     <value>木质戒指</value>
   </data>
+  <data name="Ring_WoodRing_Notes" xml:space="preserve">
+    <value>洛斯曼随机掉落</value>
+  </data>
   <data name="World_DLC1" xml:space="preserve">
     <value>真皇的苏醒DLC</value>
   </data>


### PR DESCRIPTION
I messed up in the previous PR, so let me do it again.
I tried to add simplified Chinese translations for items I owned based on PR #182 and #185. Thank you for the excellent jobs!
I am a newbie in these programming languages and PRs. It is my first time modifying a `resx` file, and I wonder if `GameStrings.zh-Hans.resx` is the only file I need to edit to get the simplified Chinese works. Let me know if I need to correct anything / modify more places.
I know there are more items in the DLC, as summarised on Reddit. I will guess their IDs and also watch other PR updates. I have already obtained most of them, excluding some random drop items. So I can put their names on once they are added with their IDs in `GameStrings.resx`.