### PR TITLE
Fix DLC Injectables from being skipped

### DIFF
--- a/RemnantSaveGuardian/RemnantWorldEvent.cs
+++ b/RemnantSaveGuardian/RemnantWorldEvent.cs
@@ -140,7 +140,7 @@ namespace RemnantSaveGuardian
             if (type.Contains("Injectable") || type.Contains("Abberation"))
             {
                 var nameSplit = _name.Split('_');
-                _name = nameSplit.Last() == "DLC" ? nameSplit[nameSplit.Length-2] : nameSplit.Last();
+                _name = nameSplit.Last() == "DLC" ? nameSplit[nameSplit.Length-2]+"_DLC" : nameSplit.Last();
             }
             if (type == "RootEarth")
             {
@@ -991,7 +991,7 @@ namespace RemnantSaveGuardian
                         {
                             currentSublocation = area.Groups["locationName"].Value;
                         }
-                        if (currentSublocation == "Consecrated Throne")
+                        if (currentSublocation == "Consecrated Throne"|| currentSublocation == "Forgotten Null")
                         {
                             continue;
                         }
@@ -1193,7 +1193,10 @@ namespace RemnantSaveGuardian
                 if (!zoneEvents.ContainsKey(world))
                 {
                     //Logger.Warn($"Injectable world {world} not found in {mode} events");
-                    continue;
+                    if (world == "World_DLC1")
+                        world = "World_Fae";
+                    else
+                        continue;
                 }
                 if (zoneEvents[world].Any(we => we._name == injectable._name))
                 {


### PR DESCRIPTION
The three injectable quests from DLC1 were being accidentally filtered out due to line 1193 jumping over the InjectablePairing since the quests had the "World_DLC1" which was not found in the ZoneEvents Dictionary.

- Replacing with World_Fae correctly inserted them into Losomns Event list since they are injectables only found in Losomn.

- Additionally Forgotten Null is a Global Quest and thus always ends up showing even if the associated Manor event is not present, which also contributed to a bug where the actual BurningCity_DLC event was not being recorded.

- Finally when parsing the DLC injectables "_DLC" was appended to their names to correctly pull from GameStrings.resx.