### PR TITLE
Add another guard for invalid keys

### DIFF
--- a/RemnantSaveGuardian/RemnantWorldEvent.cs
+++ b/RemnantSaveGuardian/RemnantWorldEvent.cs
@@ -1274,6 +1274,11 @@ namespace RemnantSaveGuardian
                     else
                         continue;
                 }
+                if (!zoneEvents.ContainsKey(world))
+                {
+                    Logger.Warn($"Injectable world {world} not found in {mode} events");
+                    continue;
+                }
                 if (zoneEvents[world].Any(we => we._name == injectable._name))
                 {
                     // injectable already exists


### PR DESCRIPTION
I kept having an error about "World Jungle" key when trying to view stuff about my save. So I added another guard against invalid keys. I still sometimes need the wrong world on rooms, but it doesn't cease to function now.